### PR TITLE
Fix parameter not found in argocd app

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -1,9 +1,8 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
-local params = inv.parameters.openshift4_olm;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('openshift4-olm', params.namespace) {
+local app = argocd.App('openshift4-olm', 'openshift-marketplace') {
   spec+: {
     syncPolicy+: {
       syncOptions+: [


### PR DESCRIPTION
The generation of the argocd app still relied on the removed namespace parameter.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
